### PR TITLE
fix: disable apscheduler tests (processpool failures in nix sandbox)

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -30,6 +30,10 @@ let
         # cherrypy test_logging tests crash in macOS Nix sandbox (signal 0)
         doCheck = false;
       });
+      apscheduler = prev.apscheduler.overridePythonAttrs (_old: {
+        # apscheduler processpool tests fail in the nix sandbox (signal handling)
+        doCheck = false;
+      });
       tenacity = prev.tenacity.overridePythonAttrs (_old: rec {
         # hermes-agent >=0.4.0 requires tenacity >=9.1.4; nixpkgs has 9.1.2
         version = "9.1.4";


### PR DESCRIPTION
## Summary
- Add `apscheduler` to the `packageOverrides` with `doCheck = false`
- The processpool executor tests assert specific signal exit codes that differ inside the nix build sandbox
- Same class of issue as the existing sanic/cherrypy/pytest-services overrides

Fixes #2 (the apscheduler part — skills PermissionError is a separate fix)

## Test plan
- [x] `nix flake show` evaluates cleanly
- [ ] `nixos-rebuild switch` succeeds on a NixOS machine using the module