### PR TITLE
chore: update Hermes Agent nightly candidate

### DIFF
--- a/nightly.nix
+++ b/nightly.nix
@@ -2,7 +2,7 @@
 # Auto-updated by scripts/update-nightly.sh — do not edit manually.
 { pkgs }:
 pkgs.callPackage ./package.nix {
-  pinVersion = "0.4.0-unstable-2026-03-25";
-  pinRev = "e5691eed38716bce6d55fa83e62d92e3c327c437";
-  pinHash = "sha256-+tJLd9PSdULdm4gsoWaonRx9NrZsNiiZ0wMUOP7Adek=";
+  pinVersion = "0.19.0-unstable-2026-07-22.9eb7b1a6";
+  pinRev = "9eb7b1a6b1ffdd4ad1a85aee3f38edceee2b927f";
+  pinHash = "sha256-baXMhFvdjbw6nW0TChPWlBZrCRxFCnyLJ1Pe7IjGDUA=";
 }

--- a/package.nix
+++ b/package.nix
@@ -206,6 +206,8 @@ pythonPackages.buildPythonApplication {
     platformdirs
     # Skills Hub
     pyjwt
+    cryptography
+    pillow
     # Messaging
     python-telegram-bot
     discordpy


### PR DESCRIPTION
## Hermes Agent nightly candidate

This PR is a quarantined upstream candidate. Merge it only after required checks pass.

| Contract | Current | Candidate |
| --- | --- | --- |
| Version | `0.4.0-unstable-2026-03-25` | `0.19.0-unstable-2026-07-22.9eb7b1a6` |
| Revision | `e5691eed38716bce6d55fa83e62d92e3c327c437` | `9eb7b1a6b1ffdd4ad1a85aee3f38edceee2b927f` |
| Python | `>=3.11` | `>=3.11,<3.14` |
| Config schema | `10` | `33` |
| Build validation | — | ❌ failed |

### Detected interface changes

- Direct dependencies: added: `certifi`, `concurrent-log-handler`, `croniter`, `cryptography`, `fastapi`, `markdown`, `packaging`, `pathspec`, `pillow`, `psutil`, `ptyprocess`, `python-multipart`, `pywin32`, `pywinpty`, `ruamel.yaml`, `tzdata`, `urllib3`, `uvicorn`, `websockets`; removed: `anthropic`, `edge-tts`, `fal-client`, `faster-whisper`, `firecrawl-py`, `parallel-web`; changed: `fire` (`fire>=0.7.1,<1` → `fire==0.7.1`), `httpx` (`httpx>=0.28.1,<1` → `httpx[socks]==0.28.1`), `jinja2` (`jinja2>=3.1.5,<4` → `jinja2==3.1.6`), `openai` (`openai>=2.21.0,<3` → `openai==2.24.0`), `prompt_toolkit` (`prompt_toolkit>=3.0.52,<4` → `prompt_toolkit==3.0.52`), `pydantic` (`pydantic>=2.12.5,<3` → `pydantic==2.13.4`), `pyjwt` (`PyJWT[crypto]>=2.10.1,<3` → `PyJWT[crypto]==2.13.0`), `python-dotenv` (`python-dotenv>=1.2.1,<2` → `python-dotenv==1.2.2`), `pyyaml` (`pyyaml>=6.0.2,<7` → `pyyaml==6.0.3`), `requests` (`requests>=2.32.3,<3` → `requests==2.33.0`), `rich` (`rich>=14.3.3,<15` → `rich==14.3.3`), `tenacity` (`tenacity>=9.1.4,<10` → `tenacity==9.1.4`)
- Optional dependency groups: added: `anthropic`, `azure-identity`, `bedrock`, `computer-use`, `edge-tts`, `exa`, `fal`, `feishu`, `firecrawl`, `google`, `hindsight`, `mem0`, `mistral`, `nemo-relay`, `parallel-web`, `supermemory`, `teams`, `termux`, `termux-all`, `vertex`, `vision`, `web`, `wecom`, `youtube`; removed: `rl`, `yc-bench`
- CLI entry points: none
- Package/module asset paths: none

Upstream: https://github.com/NousResearch/hermes-agent/commit/9eb7b1a6b1ffdd4ad1a85aee3f38edceee2b927f

<details><summary>Validation failure (last 80 lines)</summary>

```text
building '/nix/store/9rli7r81lc8axgm0mzmq0hv1y9zamway-python3.12-runs-1.2.2.drv'...
building '/nix/store/9rli7r81lc8axgm0mzmq0hv1y9zamway-python3.12-runs-1.2.2.drv'...
building '/nix/store/vhh8kv83bqdmdxfpi8kv5mac157k1sv1-python3.12-zope-testing-6.1.drv'...
building '/nix/store/lh49sn4h8kna3s0rpa6dzb960liydsy2-python3.12-zope-testrunner-8.1.drv'...
building '/nix/store/ka06bsjz5bqj54j4537y7ndnxmmann3d-python3.12-zope-configuration-7.0.drv'...
building '/nix/store/ka06bsjz5bqj54j4537y7ndnxmmann3d-python3.12-zope-configuration-7.0.drv'...
building '/nix/store/vhh8kv83bqdmdxfpi8kv5mac157k1sv1-python3.12-zope-testing-6.1.drv'...
building '/nix/store/lh49sn4h8kna3s0rpa6dzb960liydsy2-python3.12-zope-testrunner-8.1.drv'...
building '/nix/store/j4cx9g2rrp74n3wl8dv4fhgzwfcjswha-python3.12-editor-1.6.6.drv'...
building '/nix/store/j4cx9g2rrp74n3wl8dv4fhgzwfcjswha-python3.12-editor-1.6.6.drv'...
building '/nix/store/vhh8kv83bqdmdxfpi8kv5mac157k1sv1-python3.12-zope-testing-6.1.drv'...
building '/nix/store/lh49sn4h8kna3s0rpa6dzb960liydsy2-python3.12-zope-testrunner-8.1.drv'...
building '/nix/store/im4vcbjqg3npg9p6v3l28dlascw0rcqr-python3.12-zope-component-7.0.drv'...
building '/nix/store/im4vcbjqg3npg9p6v3l28dlascw0rcqr-python3.12-zope-component-7.0.drv'...
building '/nix/store/vhh8kv83bqdmdxfpi8kv5mac157k1sv1-python3.12-zope-testing-6.1.drv'...
building '/nix/store/lh49sn4h8kna3s0rpa6dzb960liydsy2-python3.12-zope-testrunner-8.1.drv'...
building '/nix/store/vhh8kv83bqdmdxfpi8kv5mac157k1sv1-python3.12-zope-testing-6.1.drv'...
building '/nix/store/lh49sn4h8kna3s0rpa6dzb960liydsy2-python3.12-zope-testrunner-8.1.drv'...
building '/nix/store/0lcyxxzdphid2cpwrzb6aq2gw8bjwjqc-python3.12-inquirer-3.4.1.drv'...
building '/nix/store/0lcyxxzdphid2cpwrzb6aq2gw8bjwjqc-python3.12-inquirer-3.4.1.drv'...
building '/nix/store/lh49sn4h8kna3s0rpa6dzb960liydsy2-python3.12-zope-testrunner-8.1.drv'...
building '/nix/store/xk0q4j1zyjaq89p7r35w9hplgfxra82v-python3.12-zc-lockfile-4.0.drv'...
building '/nix/store/xk0q4j1zyjaq89p7r35w9hplgfxra82v-python3.12-zc-lockfile-4.0.drv'...
building '/nix/store/lh49sn4h8kna3s0rpa6dzb960liydsy2-python3.12-zope-testrunner-8.1.drv'...
building '/nix/store/lh49sn4h8kna3s0rpa6dzb960liydsy2-python3.12-zope-testrunner-8.1.drv'...
building '/nix/store/yq99sxhwhaprfdldaqrbwrh5zwinh17y-python3.12-cherrypy-18.10.0.drv'...
building '/nix/store/yq99sxhwhaprfdldaqrbwrh5zwinh17y-python3.12-cherrypy-18.10.0.drv'...
building '/nix/store/ypfis2x1yr8n6rzygcanviqg4fzcwjvf-python3.12-zope-deprecation-6.0.drv'...
building '/nix/store/ypfis2x1yr8n6rzygcanviqg4fzcwjvf-python3.12-zope-deprecation-6.0.drv'...
building '/nix/store/azcd26y624i1lgvbi04gvjyvp8n7c284-python3.12-pyramid-2.0.2.drv'...
building '/nix/store/34dw2pymhpv18zbw7r2kamgvx6vsx8kh-python3.12-chalice-1.32.0.drv'...
building '/nix/store/acnmrnxaamc9qvgxv7awzrpr4j7him3i-python3.12-faster-whisper-1.2.1.drv'...
building '/nix/store/m0n0d3chzfkq3fk23k7frb3hb1lsxd27-python3.12-slack-bolt-1.27.0.drv'...
building '/nix/store/6bn9xmkbmdb6w58kyrqlpp6xm7qzwapm-hermes-agent-0.19.0-unstable-2026-07-22.9eb7b1a6.drv'...
error: Cannot build '/nix/store/6bn9xmkbmdb6w58kyrqlpp6xm7qzwapm-hermes-agent-0.19.0-unstable-2026-07-22.9eb7b1a6.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/b36vxrdkm2ivzqli2gm8skcxkrn9cwid-hermes-agent-0.19.0-unstable-2026-07-22.9eb7b1a6-dist
         /nix/store/gjsxb3avb2xqaidx66fa6hzk1dafdvz7-hermes-agent-0.19.0-unstable-2026-07-22.9eb7b1a6
       Last 25 log lines:
       > adding 'tui_gateway/project_tree.py'
       > adding 'tui_gateway/render.py'
       > adding 'tui_gateway/server.py'
       > adding 'tui_gateway/slash_worker.py'
       > adding 'tui_gateway/synthetic_turn.py'
       > adding 'tui_gateway/transport.py'
       > adding 'tui_gateway/ws.py'
       > adding 'hermes_agent-0.19.0.dist-info/METADATA'
       > adding 'hermes_agent-0.19.0.dist-info/WHEEL'
       > adding 'hermes_agent-0.19.0.dist-info/entry_points.txt'
       > adding 'hermes_agent-0.19.0.dist-info/top_level.txt'
       > adding 'hermes_agent-0.19.0.dist-info/RECORD'
       > removing build/bdist.linux-x86_64/wheel
       > Successfully built hermes_agent-0.19.0-py3-none-any.whl
       > Finished creating a wheel...
       > /build/source/dist /build/source
       > Unpacking to: unpacked/hermes_agent-0.19.0...OK
       > Repacking wheel as ./hermes_agent-0.19.0-py3-none-any.whl...OK
       > /build/source
       > Finished executing pypaBuildPhase
       > Running phase: pythonRuntimeDepsCheckHook
       > Executing pythonRuntimeDepsCheck
       > Checking runtime dependencies for hermes_agent-0.19.0-py3-none-any.whl
       >   - cryptography not installed
       >   - pillow not installed
       For full logs, run:
         nix log /nix/store/6bn9xmkbmdb6w58kyrqlpp6xm7qzwapm-hermes-agent-0.19.0-unstable-2026-07-22.9eb7b1a6.drv
error: Cannot build '/nix/store/5xfb20fyf1x1q4pxlzrmign69qzd6hny-hermes-agent-import.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/4mp6g3yzbpvr4wvfdbpnmkzlw935bgz2-hermes-agent-import
error: Cannot build '/nix/store/2rckridjdmiwm0n04wb56dq9aqfs85r3-unit-hermes-agent.service.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/57sbapgwhmyv30i38r7nj0g6xzha814v-unit-hermes-agent.service
❌ git+file:///home/runner/work/nix-hermes-agent/nix-hermes-agent#legacyPackages.x86_64-linux.nightlyChecks.all
error: Cannot build '/nix/store/zrijxj7f7zykccgasp3mkyrqbmdh1x8v-hermes-agent-nightly-checks.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/w9lx3q56cq1wfzllq541340mysyhwgcq-hermes-agent-nightly-checks
```
</details>
