### PR TITLE
chore: update Hermes Agent stable candidate

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -9,9 +9,9 @@
   ripgrep,
   ffmpeg,
   git,
-  pinVersion ? "0.16.0",
-  pinRev ? "3c231eb3979ab9c57d5cd6d02f1d577a3b718b43",
-  pinHash ? "sha256-ngpkopVczNrT0bfCXHm38QjgrZT96Bm/rO89NA/ls3Y=",
+  pinVersion ? "0.19.0",
+  pinRev ? "3ef6bbd201263d354fd83ec55b3c306ded2eb72a",
+  pinHash ? "sha256-QJEiBOLAVGeYBym4EUtnDgeIyJyDQWgmat70/yujiz4=",
 }:
 
 let

--- a/package.nix
+++ b/package.nix
@@ -206,6 +206,8 @@ pythonPackages.buildPythonApplication {
     platformdirs
     # Skills Hub
     pyjwt
+    cryptography
+    pillow
     # Messaging
     python-telegram-bot
     discordpy


### PR DESCRIPTION
## Hermes Agent stable candidate

This PR is a quarantined upstream candidate. Merge it only after required checks pass.

| Contract | Current | Candidate |
| --- | --- | --- |
| Version | `0.16.0` | `0.19.0` |
| Revision | `3c231eb3979ab9c57d5cd6d02f1d577a3b718b43` | `3ef6bbd201263d354fd83ec55b3c306ded2eb72a` |
| Python | `>=3.11,<3.14` | `>=3.11,<3.14` |
| Config schema | `27` | `33` |
| Build validation | — | ❌ failed |

### Detected interface changes

- Direct dependencies: added: `certifi`, `concurrent-log-handler`, `cryptography`, `packaging`, `pillow`, `python-multipart`, `urllib3`, `websockets`; changed: `pyjwt` (`PyJWT[crypto]==2.12.1` → `PyJWT[crypto]==2.13.0`)
- Optional dependency groups: added: `mem0`, `supermemory`, `teams`, `vertex`
- CLI entry points: none
- Package/module asset paths: none

Upstream: https://github.com/NousResearch/hermes-agent/releases/tag/v2026.7.20

<details><summary>Validation failure (last 80 lines)</summary>

```text
       > adding 'tui_gateway/render.py'
       > adding 'tui_gateway/server.py'
       > adding 'tui_gateway/slash_worker.py'
       > adding 'tui_gateway/synthetic_turn.py'
       > adding 'tui_gateway/transport.py'
       > adding 'tui_gateway/ws.py'
       > adding 'hermes_agent-0.19.0.dist-info/METADATA'
       > adding 'hermes_agent-0.19.0.dist-info/WHEEL'
       > adding 'hermes_agent-0.19.0.dist-info/entry_points.txt'
       > adding 'hermes_agent-0.19.0.dist-info/top_level.txt'
       > adding 'hermes_agent-0.19.0.dist-info/RECORD'
       > removing build/bdist.linux-x86_64/wheel
       > Successfully built hermes_agent-0.19.0-py3-none-any.whl
       > Finished creating a wheel...
       > /build/source/dist /build/source
       > Unpacking to: unpacked/hermes_agent-0.19.0...OK
       > Repacking wheel as ./hermes_agent-0.19.0-py3-none-any.whl...OK
       > /build/source
       > Finished executing pypaBuildPhase
       > Running phase: pythonRuntimeDepsCheckHook
       > Executing pythonRuntimeDepsCheck
       > Checking runtime dependencies for hermes_agent-0.19.0-py3-none-any.whl
       >   - cryptography not installed
       >   - pillow not installed
       For full logs, run:
         nix log /nix/store/6qlsgqbrf4hq6b57a51wgk59fpji2d8q-hermes-agent-0.19.0.drv
❌ checks.x86_64-linux.hermes-agent-import
error: Cannot build '/nix/store/6vii9v06g9isv0x2crbxmllqr0m90z1g-hermes-agent-import.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/n9grb30dba57v5s0h2brx6ibbb2azf5r-hermes-agent-import
error: Cannot build '/nix/store/bxfg5zwmwjxiz4zmn7g19yj959sgzynz-unit-hermes-agent.service.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/swyx1sa15np5nig3p5l512a3xwsm3hfy-unit-hermes-agent.service
❌ checks.x86_64-linux.doctor
error: Cannot build '/nix/store/bz1jnpcnifvr6djz4r8kwd06wx9kv420-hermes-doctor.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/4wshvbn1jprlcx72p87i88jy9cp89ih7-hermes-doctor
error: Cannot build '/nix/store/cw6sbkdh619cw9vpp39bdjb0cglblaz5-nixos-vm.drv'.
       Reason: 2 dependencies failed.
       Output paths:
         /nix/store/kzffz9bcflzhj0xwmvpvc02962qb329k-nixos-vm
error: Cannot build '/nix/store/d02387f0gngw2gyyp4a2kq104zhfccw2-nixos-system-machine-test.drv'.
       Reason: 2 dependencies failed.
       Output paths:
         /nix/store/vzg7j1lcij2k9kcsr3l01rwc4aa26ksl-nixos-system-machine-test
error: Cannot build '/nix/store/ivjcdb4hqbrjy4d8hh8bf2hk509yq1av-activate.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/npfqk6b4ws18rddymv37rv2s9bq6n3ka-activate
error: Cannot build '/nix/store/j6m413kvmsgv3kpbpllj5rya92n7xvrm-system-units.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/j53m8fp7zb9zjbbgkzxgk9q98z6aijcb-system-units
error: Cannot build '/nix/store/jrx8w1s4rw79l8jvsrig5vxwmppn9vrv-run-nixos-vm.drv'.
       Reason: 2 dependencies failed.
       Output paths:
         /nix/store/4qggnlfijkj77ivx9ijm80qm6izqlr0a-run-nixos-vm
error: Cannot build '/nix/store/kf6iiwj4359fvqvy9irs30lhq1kqylav-nixos-test-driver-hermes-skills-coexistence.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/g765iha6j2in2h1f78xxlx1sgkzz1fq0-nixos-test-driver-hermes-skills-coexistence
error: Cannot build '/nix/store/lmiq9bl3iz95073gs7mr2w59yinjp72q-etc.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/jij41kadkdah8gw23brvppg5ngk7f8r2-etc
❌ checks.x86_64-linux.skills-coexistence
error: Cannot build '/nix/store/q8p5kmfvisyf2z3b3wa95qfx18x7qs06-vm-test-run-hermes-skills-coexistence.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/ki446z7r66h6dlj8dr53z1hpn4jbjm0q-vm-test-run-hermes-skills-coexistence
❌ checks.x86_64-linux.cli-commands
error: Cannot build '/nix/store/z3k18miw6xbipkpkkr2sad3d9ya04yfp-hermes-cli-commands.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/mii9j3z1kfhdh8a59vfzn7985z2smk75-hermes-cli-commands
warning: The check omitted these incompatible systems: aarch64-darwin, aarch64-linux, x86_64-darwin
Use '--all-systems' to check all.
```
</details>
