### PR TITLE
chore: update Hermes Agent nightly candidate

### DIFF
--- a/nightly.nix
+++ b/nightly.nix
@@ -2,7 +2,7 @@
 # Auto-updated by scripts/update-nightly.sh — do not edit manually.
 { pkgs }:
 pkgs.callPackage ./package.nix {
-  pinVersion = "0.19.0-unstable-2026-07-22.9eb7b1a6";
-  pinRev = "9eb7b1a6b1ffdd4ad1a85aee3f38edceee2b927f";
-  pinHash = "sha256-baXMhFvdjbw6nW0TChPWlBZrCRxFCnyLJ1Pe7IjGDUA=";
+  pinVersion = "0.20.0-unstable-2026-08-12.76d832d3";
+  pinRev = "76d832d3857551a029c4b39c23945eb47c16fe5b";
+  pinHash = "sha256-PxPrQ//AlMou4cbVB1ceSJT+65dP9iwK5eUzPyUwkac=";
 }


### PR DESCRIPTION
## Hermes Agent nightly candidate

This PR is a quarantined upstream candidate. Merge it only after required checks pass.

| Contract | Current | Candidate |
| --- | --- | --- |
| Version | `0.19.0-unstable-2026-07-22.9eb7b1a6` | `0.20.0-unstable-2026-08-12.76d832d3` |
| Revision | `9eb7b1a6b1ffdd4ad1a85aee3f38edceee2b927f` | `76d832d3857551a029c4b39c23945eb47c16fe5b` |
| Python | `>=3.11,<3.14` | `>=3.11,<3.14` |
| Config schema | `33` | `unknown` |
| Build validation | — | ❌ failed |

### Detected interface changes

- Direct dependencies: added: `nemo-relay`; changed: `cryptography` (`cryptography==46.0.7` → `cryptography==50.0.0`), `pillow` (`Pillow==12.2.0` → `Pillow==12.3.0`)
- Optional dependency groups: added: `otlp`, `vercel`, `wake`; removed: `cli`
- CLI entry points: none
- Package/module asset paths: none

Upstream: https://github.com/NousResearch/hermes-agent/commit/76d832d3857551a029c4b39c23945eb47c16fe5b

<details><summary>Validation failure (last 80 lines)</summary>

```text
building '/nix/store/j4cx9g2rrp74n3wl8dv4fhgzwfcjswha-python3.12-editor-1.6.6.drv'...
building '/nix/store/lh49sn4h8kna3s0rpa6dzb960liydsy2-python3.12-zope-testrunner-8.1.drv'...
building '/nix/store/8d1f6dr3qs9n5vlrw0mbql6zsbl0kvml-tenacity-9.1.4.tar.gz.drv'...
building '/nix/store/xk0q4j1zyjaq89p7r35w9hplgfxra82v-python3.12-zc-lockfile-4.0.drv'...
building '/nix/store/xk0q4j1zyjaq89p7r35w9hplgfxra82v-python3.12-zc-lockfile-4.0.drv'...
building '/nix/store/lh49sn4h8kna3s0rpa6dzb960liydsy2-python3.12-zope-testrunner-8.1.drv'...
building '/nix/store/8d1f6dr3qs9n5vlrw0mbql6zsbl0kvml-tenacity-9.1.4.tar.gz.drv'...
building '/nix/store/0lcyxxzdphid2cpwrzb6aq2gw8bjwjqc-python3.12-inquirer-3.4.1.drv'...
building '/nix/store/0lcyxxzdphid2cpwrzb6aq2gw8bjwjqc-python3.12-inquirer-3.4.1.drv'...
building '/nix/store/lh49sn4h8kna3s0rpa6dzb960liydsy2-python3.12-zope-testrunner-8.1.drv'...
building '/nix/store/8d1f6dr3qs9n5vlrw0mbql6zsbl0kvml-tenacity-9.1.4.tar.gz.drv'...
building '/nix/store/lh49sn4h8kna3s0rpa6dzb960liydsy2-python3.12-zope-testrunner-8.1.drv'...
building '/nix/store/8d1f6dr3qs9n5vlrw0mbql6zsbl0kvml-tenacity-9.1.4.tar.gz.drv'...
building '/nix/store/yq99sxhwhaprfdldaqrbwrh5zwinh17y-python3.12-cherrypy-18.10.0.drv'...
building '/nix/store/yq99sxhwhaprfdldaqrbwrh5zwinh17y-python3.12-cherrypy-18.10.0.drv'...
building '/nix/store/8d1f6dr3qs9n5vlrw0mbql6zsbl0kvml-tenacity-9.1.4.tar.gz.drv'...
building '/nix/store/ypfis2x1yr8n6rzygcanviqg4fzcwjvf-python3.12-zope-deprecation-6.0.drv'...
building '/nix/store/ypfis2x1yr8n6rzygcanviqg4fzcwjvf-python3.12-zope-deprecation-6.0.drv'...
building '/nix/store/8d1f6dr3qs9n5vlrw0mbql6zsbl0kvml-tenacity-9.1.4.tar.gz.drv'...
building '/nix/store/8d1f6dr3qs9n5vlrw0mbql6zsbl0kvml-tenacity-9.1.4.tar.gz.drv'...
building '/nix/store/azcd26y624i1lgvbi04gvjyvp8n7c284-python3.12-pyramid-2.0.2.drv'...
building '/nix/store/azcd26y624i1lgvbi04gvjyvp8n7c284-python3.12-pyramid-2.0.2.drv'...
building '/nix/store/xqyq8wfmcay0iwamwwidwdicpazbp6p2-python3.12-tenacity-9.1.4.drv'...
building '/nix/store/xqyq8wfmcay0iwamwwidwdicpazbp6p2-python3.12-tenacity-9.1.4.drv'...
building '/nix/store/34dw2pymhpv18zbw7r2kamgvx6vsx8kh-python3.12-chalice-1.32.0.drv'...
building '/nix/store/34dw2pymhpv18zbw7r2kamgvx6vsx8kh-python3.12-chalice-1.32.0.drv'...
building '/nix/store/4nx6w7y6h260n16d811k9kndb21514z5-python3.12-sse-starlette-3.2.0.drv'...
building '/nix/store/4nx6w7y6h260n16d811k9kndb21514z5-python3.12-sse-starlette-3.2.0.drv'...
building '/nix/store/acnmrnxaamc9qvgxv7awzrpr4j7him3i-python3.12-faster-whisper-1.2.1.drv'...
building '/nix/store/8ggzd7x16vsplx2alkd7z46xmaqw7ghc-python3.12-httpx-sse-0.4.3.drv'...
building '/nix/store/dkir7i5b17ynixnnk2xjv4cpvik9kk9h-python3.12-fal-client-0.13.1.drv'...
building '/nix/store/m4f4dds3gc5c1ivxvj2cvl4wwfcbmsvf-python3.12-mcp-1.26.0.drv'...
building '/nix/store/m0n0d3chzfkq3fk23k7frb3hb1lsxd27-python3.12-slack-bolt-1.27.0.drv'...
building '/nix/store/pwllcf1aab1hl1990wn3rqarc295prb6-hermes-agent-0.20.0-unstable-2026-08-12.76d832d3.drv'...
error: Cannot build '/nix/store/pwllcf1aab1hl1990wn3rqarc295prb6-hermes-agent-0.20.0-unstable-2026-08-12.76d832d3.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/2nwsq10y0yzyplcvvk6k1j880j9y19qr-hermes-agent-0.20.0-unstable-2026-08-12.76d832d3-dist
         /nix/store/l1rx00pq4j2vqc3g7wqhm9vqs0gwslk0-hermes-agent-0.20.0-unstable-2026-08-12.76d832d3
       Last 25 log lines:
       > source root is source
       > setting SOURCE_DATE_EPOCH to timestamp 315619200 of file "source/website/tsconfig.json"
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > no configure script, doing nothing
       > Running phase: buildPhase
       > Executing pypaBuildPhase
       > Creating a wheel...
       > pypa build flags: --no-isolation --outdir dist/ --wheel
       > * Getting build dependencies for wheel...
       > running egg_info
       > creating hermes_agent.egg-info
       > writing hermes_agent.egg-info/PKG-INFO
       > writing dependency_links to hermes_agent.egg-info/dependency_links.txt
       > writing entry points to hermes_agent.egg-info/entry_points.txt
       > writing requirements to hermes_agent.egg-info/requires.txt
       > writing top-level names to hermes_agent.egg-info/top_level.txt
       > writing manifest file 'hermes_agent.egg-info/SOURCES.txt'
       > reading manifest file 'hermes_agent.egg-info/SOURCES.txt'
       > adding license file 'LICENSE'
       > writing manifest file 'hermes_agent.egg-info/SOURCES.txt'
       >
       > ERROR Missing dependencies:
       >         setuptools==83.0.0
       For full logs, run:
         nix log /nix/store/pwllcf1aab1hl1990wn3rqarc295prb6-hermes-agent-0.20.0-unstable-2026-08-12.76d832d3.drv
error: Cannot build '/nix/store/nvnbdm5szj0n5hm026v331f404v8270q-hermes-agent-import.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/avshxb4gik6q40a0lyn8bypdh5gnc4h1-hermes-agent-import
error: Cannot build '/nix/store/a87jgwhchapf0s9md6zd6kh572iv2naw-unit-hermes-agent.service.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/4dqa74s0mbpcpfznr687x4sxg7m2p5n5-unit-hermes-agent.service
❌ git+file:///home/runner/work/nix-hermes-agent/nix-hermes-agent#legacyPackages.x86_64-linux.nightlyChecks.all
error: Cannot build '/nix/store/pi7rvhmka0bzif759n8x9xfnzwjsl6g4-hermes-agent-nightly-checks.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/zyqb3dwz12szcimaa0dln5i1289f40nx-hermes-agent-nightly-checks
```
</details>
