### PR TITLE
chore: update Hermes Agent stable candidate

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -9,9 +9,9 @@
   ripgrep,
   ffmpeg,
   git,
-  pinVersion ? "0.19.0",
-  pinRev ? "3ef6bbd201263d354fd83ec55b3c306ded2eb72a",
-  pinHash ? "sha256-QJEiBOLAVGeYBym4EUtnDgeIyJyDQWgmat70/yujiz4=",
+  pinVersion ? "0.20.0",
+  pinRev ? "3c27eb6234bf91b8ceee9e9071591b31e9b148cb",
+  pinHash ? "sha256-S6TSGgpf37N8YgbTv70dT+LaPiiaQ4/lJV+js2hnCPk=",
 }:
 
 let

--- a/package.nix
+++ b/package.nix
@@ -4,6 +4,7 @@
   python312,
   fetchFromGitHub,
   fetchPypi,
+  fetchurl,
   makeWrapper,
   nodejs_22,
   ripgrep,
@@ -32,6 +33,11 @@ let
       });
       apscheduler = prev.apscheduler.overridePythonAttrs (_old: {
         # apscheduler processpool tests fail in the nix sandbox (signal handling)
+        doCheck = false;
+      });
+      slack-bolt = prev.slack-bolt.overridePythonAttrs (_old: {
+        # slack-bolt 1.27.0 tests crash at interpreter shutdown in the nix
+        # sandbox (_enter_buffered_busy: could not acquire lock for stderr)
         doCheck = false;
       });
       tenacity = prev.tenacity.overridePythonAttrs (_old: rec {
@@ -135,6 +141,21 @@ let
     pythonImportsCheck = [ "parallel" ];
   };
 
+  nemo-relay = pythonPackages.buildPythonPackage rec {
+    pname = "nemo-relay";
+    version = "0.6.0";
+    # Upstream 0.6.x ships only compiled abi3 wheels on PyPI (no buildable
+    # sdist for the Nix sandbox); the prebuilt manylinux wheel has no base
+    # runtime dependencies.
+    format = "wheel";
+    src = fetchurl {
+      url = "https://files.pythonhosted.org/packages/a3/f4/d1dfaed022da0f6f14765a122867f976a69cc520fe1faaf99757f5719d1f/nemo_relay-0.6.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
+      hash = "sha256-hJ2qnkUVisWB5UUG4PzHok9VfR7Qbb3AdPXeegA5PLw=";
+    };
+    doCheck = false;
+    pythonImportsCheck = [ "nemo_relay" ];
+  };
+
   agent-client-protocol = pythonPackages.buildPythonPackage rec {
     pname = "agent-client-protocol";
     version = "0.8.1";
@@ -170,6 +191,10 @@ pythonPackages.buildPythonApplication {
   pyproject = true;
 
   build-system = [ pythonPackages.setuptools ];
+
+  # Upstream setup.py refuses wheel builds unless HERMES_NIX_BUILD=1 is set;
+  # their nix/python.nix sets it in the build sandbox (see setup.py ~line 32).
+  env.HERMES_NIX_BUILD = "1";
 
   # litellm is compromised — strip it from wheel metadata so pythonRuntimeDepsCheck passes
   pythonRemoveDeps = [ "litellm" ];
@@ -231,6 +256,8 @@ pythonPackages.buildPythonApplication {
     mcp
     # ACP
     agent-client-protocol
+    # Relay (lazy-imported per profile via agent/relay_runtime.py)
+    nemo-relay
   ];
 
   nativeBuildInputs = [ makeWrapper ];
@@ -241,6 +268,10 @@ pythonPackages.buildPythonApplication {
   # Upstream pyproject.toml may be missing minisweagent_path / mini_swe_runner
   # from py-modules. Also ensure mini-swe-agent/src is importable.
   postPatch = ''
+    # Relax pinned build backend: upstream requires setuptools==83.0.0, nixpkgs
+    # (locked c06b4ae) ships 80.10.1; the exact pin fails the pypa build check.
+    sed -i 's/setuptools==83.0.0/setuptools>=80/' pyproject.toml
+
     # Fix: add minisweagent_path.py to py-modules if missing from pyproject.toml
     if [ -f minisweagent_path.py ] && ! grep -q minisweagent_path pyproject.toml; then
       sed -i 's/py-modules = \[/py-modules = ["minisweagent_path", /' pyproject.toml


### PR DESCRIPTION
## Hermes Agent stable candidate

This PR is a quarantined upstream candidate. Merge it only after required checks pass.

| Contract | Current | Candidate |
| --- | --- | --- |
| Version | `0.19.0` | `0.20.0` |
| Revision | `3ef6bbd201263d354fd83ec55b3c306ded2eb72a` | `3c27eb6234bf91b8ceee9e9071591b31e9b148cb` |
| Python | `>=3.11,<3.14` | `>=3.11,<3.14` |
| Config schema | `33` | `unknown` |
| Build validation | — | ❌ failed |

### Detected interface changes

- Direct dependencies: added: `nemo-relay`, `pywin32`; changed: `cryptography` (`cryptography==46.0.7` → `cryptography==48.0.1`), `pillow` (`Pillow==12.2.0` → `Pillow==12.3.0`)
- Optional dependency groups: added: `otlp`, `vercel`, `wake`
- CLI entry points: none
- Package/module asset paths: none

Upstream: https://github.com/NousResearch/hermes-agent/releases/tag/v2026.8.3

<details><summary>Validation failure (last 80 lines)</summary>

```text
error: Cannot build '/nix/store/43sijfbq4zy98av8vpp24b4f4b9i6hs5-closure-info.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/iwx38yw966hvcnvmdnch161lzddis11f-closure-info
❌ checks.x86_64-linux.doctor
error: Cannot build '/nix/store/4n4vzpygljjn4dkn4g0nk4wy1k05wp4a-hermes-doctor.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/y7kg7bdk8lydbhphkp4p87089j60gh1a-hermes-doctor
error: Cannot build '/nix/store/5lc67b5mxrz4bbcw37zx86jnmml0h1i5-system-units.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/rv2yvprp2sp3bfjjl8r1pc2cjah9kwn5-system-units
error: Cannot build '/nix/store/88ldaq7inxhwwpzqzh8vl79114ysb041-unit-hermes-agent.service.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/n6cp6a6iwj470q5symh26a13vvclhcg1-unit-hermes-agent.service
✅ checks.x86_64-linux.skills-source-layout
error: Cannot build '/nix/store/bzx39l5nz25nr3bdb14wzqdl0b1x9z59-activate.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/lin7f567gajpiz7wb30jw7qqv7cxmn41-activate
error: Cannot build '/nix/store/dlqjz63x75frj3rw78dybw4xqnwwy9p7-etc.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/clj8km1q6h6n2y554fl592p6ry3g3x9a-etc
❌ checks.x86_64-linux.cli-commands
error: Cannot build '/nix/store/jslazhwg8yxxchbh5vmxhibqydd6gd4i-hermes-cli-commands.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/qqn9k8gjcna8yz8qz9rbng9cpicyv70h-hermes-cli-commands
error: Cannot build '/nix/store/msgz5rgy0rdhxs86azmvkpblzcrkcl6x-nixos-vm.drv'.
       Reason: 2 dependencies failed.
       Output paths:
         /nix/store/1mr1jp82ww8bjlc2f3mw5chg28hsd023-nixos-vm
error: Cannot build '/nix/store/p6ibzvrbz8kqvklg9mshhkfd1s6k69wr-hermes-agent-0.20.0.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/2j03zwyyjqg2myw20hh3b7abg681zqnq-hermes-agent-0.20.0-dist
         /nix/store/y29h0yyvy80m5v0n0r5w0a5nizx6ps6h-hermes-agent-0.20.0
       Last 25 log lines:
       > source root is source
       > setting SOURCE_DATE_EPOCH to timestamp 315619200 of file "source/website/tsconfig.json"
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > no configure script, doing nothing
       > Running phase: buildPhase
       > Executing pypaBuildPhase
       > Creating a wheel...
       > pypa build flags: --no-isolation --outdir dist/ --wheel
       > * Getting build dependencies for wheel...
       > running egg_info
       > creating hermes_agent.egg-info
       > writing hermes_agent.egg-info/PKG-INFO
       > writing dependency_links to hermes_agent.egg-info/dependency_links.txt
       > writing entry points to hermes_agent.egg-info/entry_points.txt
       > writing requirements to hermes_agent.egg-info/requires.txt
       > writing top-level names to hermes_agent.egg-info/top_level.txt
       > writing manifest file 'hermes_agent.egg-info/SOURCES.txt'
       > reading manifest file 'hermes_agent.egg-info/SOURCES.txt'
       > adding license file 'LICENSE'
       > writing manifest file 'hermes_agent.egg-info/SOURCES.txt'
       >
       > ERROR Missing dependencies:
       >        setuptools==83.0.0
       For full logs, run:
         nix log /nix/store/p6ibzvrbz8kqvklg9mshhkfd1s6k69wr-hermes-agent-0.20.0.drv
❌ checks.x86_64-linux.package-contents
error: Cannot build '/nix/store/vcx2bsgbzfjh5gk7kjmfzaynzj58j2jv-hermes-package-contents.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/681bq18v65zyac2v0zizanj7lmlcp1gk-hermes-package-contents
❌ checks.x86_64-linux.hermes-agent-import
error: Cannot build '/nix/store/zgsjyyydc92899b3gbi2namd1z1qnqsc-hermes-agent-import.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/cngnmk5qv3bssk47w3x1c0n6mb375nh9-hermes-agent-import
warning: The check omitted these incompatible systems: aarch64-darwin, aarch64-linux, x86_64-darwin
Use '--all-systems' to check all.
```
</details>
