### PR TITLE
chore: update Hermes Agent nightly candidate

### DIFF
--- a/nightly.nix
+++ b/nightly.nix
@@ -2,7 +2,7 @@
 # Auto-updated by scripts/update-nightly.sh — do not edit manually.
 { pkgs }:
 pkgs.callPackage ./package.nix {
-  pinVersion = "0.19.0-unstable-2026-07-22.9eb7b1a6";
-  pinRev = "9eb7b1a6b1ffdd4ad1a85aee3f38edceee2b927f";
-  pinHash = "sha256-baXMhFvdjbw6nW0TChPWlBZrCRxFCnyLJ1Pe7IjGDUA=";
+  pinVersion = "0.20.1-unstable-2026-08-14.9504edba";
+  pinRev = "9504edbaea29ce249864a1be05819d972f8fae8d";
+  pinHash = "sha256-hZHeylSgU71r/x3WMOrmcARcKSx5y17l9vwFgbde5ks=";
 }


### PR DESCRIPTION
## Hermes Agent nightly candidate

This PR is a quarantined upstream candidate. Merge it only after required checks pass.

| Contract | Current | Candidate |
| --- | --- | --- |
| Version | `0.19.0-unstable-2026-07-22.9eb7b1a6` | `0.20.1-unstable-2026-08-14.9504edba` |
| Revision | `9eb7b1a6b1ffdd4ad1a85aee3f38edceee2b927f` | `9504edbaea29ce249864a1be05819d972f8fae8d` |
| Python | `>=3.11,<3.14` | `>=3.11,<3.14` |
| Config schema | `33` | `unknown` |
| Build validation | — | ✅ passed |

### Detected interface changes

- Direct dependencies: added: `nemo-relay`; changed: `cryptography` (`cryptography==46.0.7` → `cryptography==50.0.0`), `pillow` (`Pillow==12.2.0` → `Pillow==12.3.0`)
- Optional dependency groups: added: `otlp`, `vercel`, `wake`; removed: `cli`
- CLI entry points: none
- Package/module asset paths: none

Upstream: https://github.com/NousResearch/hermes-agent/commit/9504edbaea29ce249864a1be05819d972f8fae8d
