### PR TITLE
chore: update Hermes Agent stable candidate

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -10,9 +10,9 @@
   ripgrep,
   ffmpeg,
   git,
-  pinVersion ? "0.20.1",
-  pinRev ? "f80f453ae0679347e38abc917c7f94f717bf96c5",
-  pinHash ? "sha256-A+pprddWqewhUjD8d+PLdTHAO5SZV6YwPhJrC2T2dFE=",
+  pinVersion ? "0.20.2",
+  pinRev ? "df4b65147d7ddd74dd449f9067aabbca5aef0ec7",
+  pinHash ? "sha256-TsWcNR6JVj+PaqwodGrtcIgmOG6bzXtIDWw+e2txPdk=",
 }:
 
 let


### PR DESCRIPTION
## Hermes Agent stable candidate

This PR is a quarantined upstream candidate. Merge it only after required checks pass.

| Contract | Current | Candidate |
| --- | --- | --- |
| Version | `0.20.1` | `0.20.2` |
| Revision | `f80f453ae0679347e38abc917c7f94f717bf96c5` | `df4b65147d7ddd74dd449f9067aabbca5aef0ec7` |
| Python | `>=3.11,<3.14` | `>=3.11,<3.14` |
| Config schema | `unknown` | `unknown` |
| Build validation | — | ✅ passed |

### Detected interface changes

- Direct dependencies: none
- Optional dependency groups: none
- CLI entry points: none
- Package/module asset paths: none

Upstream: https://github.com/NousResearch/hermes-agent/releases/tag/v2026.8.16
