### PR TITLE
chore: update Hermes Agent nightly candidate

### DIFF
--- a/nightly.nix
+++ b/nightly.nix
@@ -2,7 +2,7 @@
 # Auto-updated by scripts/update-nightly.sh — do not edit manually.
 { pkgs }:
 pkgs.callPackage ./package.nix {
-  pinVersion = "0.20.2-unstable-2026-08-17.3b9a963b";
-  pinRev = "3b9a963b8e5cdb804a422755bed9a60fcd778273";
-  pinHash = "sha256-fq0Qci8Ez0Bn7MVmz73kZfpl9zA+0bAKrOEt6ExKt8I=";
+  pinVersion = "0.20.3-unstable-2026-08-18.bdc9a810";
+  pinRev = "bdc9a810f3990597b3f26203348e849e5128afb6";
+  pinHash = "sha256-+eoh8rq+U+sflD35vXibjlikB7zS4nVrsJFl1kVdMU4=";
 }


### PR DESCRIPTION
## Hermes Agent nightly candidate

This PR is a quarantined upstream candidate. Merge it only after required checks pass.

| Contract | Current | Candidate |
| --- | --- | --- |
| Version | `0.20.2-unstable-2026-08-17.3b9a963b` | `0.20.3-unstable-2026-08-18.bdc9a810` |
| Revision | `3b9a963b8e5cdb804a422755bed9a60fcd778273` | `bdc9a810f3990597b3f26203348e849e5128afb6` |
| Python | `>=3.11,<3.14` | `>=3.11,<3.14` |
| Config schema | `unknown` | `unknown` |
| Build validation | — | ✅ passed |

### Detected interface changes

- Direct dependencies: none
- Optional dependency groups: none
- CLI entry points: none
- Package/module asset paths: none

Upstream: https://github.com/NousResearch/hermes-agent/commit/bdc9a810f3990597b3f26203348e849e5128afb6
