### PR TITLE
chore: update Hermes Agent stable candidate

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -10,9 +10,9 @@
   ripgrep,
   ffmpeg,
   git,
-  pinVersion ? "0.20.2",
-  pinRev ? "df4b65147d7ddd74dd449f9067aabbca5aef0ec7",
-  pinHash ? "sha256-TsWcNR6JVj+PaqwodGrtcIgmOG6bzXtIDWw+e2txPdk=",
+  pinVersion ? "0.20.3",
+  pinRev ? "7339f5f160db5c96657a3bab60151227cc61f66c",
+  pinHash ? "sha256-NoURyVuZ4EvG4K3S2oKSfJctVH9rXk4oeoXHWBNddPw=",
 }:
 
 let


### PR DESCRIPTION
## Hermes Agent stable candidate

This PR is a quarantined upstream candidate. Merge it only after required checks pass.

| Contract | Current | Candidate |
| --- | --- | --- |
| Version | `0.20.2` | `0.20.3` |
| Revision | `df4b65147d7ddd74dd449f9067aabbca5aef0ec7` | `7339f5f160db5c96657a3bab60151227cc61f66c` |
| Python | `>=3.11,<3.14` | `>=3.11,<3.14` |
| Config schema | `unknown` | `unknown` |
| Build validation | — | ✅ passed |

### Detected interface changes

- Direct dependencies: none
- Optional dependency groups: none
- CLI entry points: none
- Package/module asset paths: none

Upstream: https://github.com/NousResearch/hermes-agent/releases/tag/v2026.8.16.2
