### PR TITLE
chore: update Hermes Agent nightly candidate

### DIFF
--- a/nightly.nix
+++ b/nightly.nix
@@ -2,7 +2,7 @@
 # Auto-updated by scripts/update-nightly.sh — do not edit manually.
 { pkgs }:
 pkgs.callPackage ./package.nix {
-  pinVersion = "0.20.3-unstable-2026-08-18.bdc9a810";
-  pinRev = "bdc9a810f3990597b3f26203348e849e5128afb6";
-  pinHash = "sha256-+eoh8rq+U+sflD35vXibjlikB7zS4nVrsJFl1kVdMU4=";
+  pinVersion = "0.20.4-unstable-2026-08-20.68518411";
+  pinRev = "6851841112e921537eb7195ef6e8be7d2ca2d2f6";
+  pinHash = "sha256-xt+9SK8IV7qQYP4c4/cVFOjgQNYhgaR/yAVTD86UsuA=";
 }


### PR DESCRIPTION
## Hermes Agent nightly candidate

This PR is a quarantined upstream candidate. Merge it only after required checks pass.

| Contract | Current | Candidate |
| --- | --- | --- |
| Version | `0.20.3-unstable-2026-08-18.bdc9a810` | `0.20.4-unstable-2026-08-20.68518411` |
| Revision | `bdc9a810f3990597b3f26203348e849e5128afb6` | `6851841112e921537eb7195ef6e8be7d2ca2d2f6` |
| Python | `>=3.11,<3.14` | `>=3.11,<3.14` |
| Config schema | `unknown` | `unknown` |
| Build validation | — | ✅ passed |

### Detected interface changes

- Direct dependencies: none
- Optional dependency groups: none
- CLI entry points: none
- Package/module asset paths: none

Upstream: https://github.com/NousResearch/hermes-agent/commit/6851841112e921537eb7195ef6e8be7d2ca2d2f6
