### PR TITLE
chore: update Hermes Agent stable candidate

### DIFF
--- a/checks.nix
+++ b/checks.nix
@@ -12,7 +12,7 @@
     echo "PASS: All binaries present"
 
     echo "=== Checking version ==="
-    ${hermes-agent}/bin/hermes version 2>&1 | grep -q "Hermes Agent" || (echo "FAIL: version check"; exit 1)
+    ${hermes-agent}/bin/hermes --version 2>&1 | grep -q "Hermes Agent" || (echo "FAIL: version check"; exit 1)
     echo "PASS: Version check"
 
     echo "=== Checking key Python modules ==="

--- a/package.nix
+++ b/package.nix
@@ -156,6 +156,21 @@ let
     pythonImportsCheck = [ "nemo_relay" ];
   };
 
+  firecrawl-anydoc = pythonPackages.buildPythonPackage rec {
+    pname = "firecrawl-anydoc";
+    version = "0.2.4";
+    # Upstream ships only Rust/maturin artifacts; the prebuilt abi3 wheel has
+    # no base runtime dependencies (PyPI requires_dist is empty). x86_64-linux
+    # wheel only — matches the system the flake's checks target.
+    format = "wheel";
+    src = fetchurl {
+      url = "https://files.pythonhosted.org/packages/fc/16/feeca9705bfdb237f1cb69ede0b373b144c0d51df4297e595a74b815557e/firecrawl_anydoc-0.2.4-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
+      hash = "sha256-DlrtAb9tTlxYjTNjiIKT8s7rn+sARJoy4LqZN5fPC9M=";
+    };
+    doCheck = false;
+    pythonImportsCheck = [ "anydoc" ];
+  };
+
   agent-client-protocol = pythonPackages.buildPythonPackage rec {
     pname = "agent-client-protocol";
     version = "0.8.1";
@@ -223,6 +238,10 @@ pythonPackages.buildPythonApplication {
     firecrawl-py
     fal-client
     parallel-web
+    # Document conversion (upstream >=0.21.0, firecrawl-anydoc==0.2.4)
+    firecrawl-anydoc
+    # tool_search BM25 stemming (upstream >=0.20.6, snowballstemmer==3.1.1)
+    snowballstemmer
     # TTS
     edge-tts
     faster-whisper

--- a/package.nix
+++ b/package.nix
@@ -10,9 +10,9 @@
   ripgrep,
   ffmpeg,
   git,
-  pinVersion ? "0.20.4",
-  pinRev ? "e624e9fde561e1add9388384012b295fde669ade",
-  pinHash ? "sha256-LyI50ipeOVOcQ7tpoh+ofiEhxW3qW9pTJNUK7deJkYE=",
+  pinVersion ? "0.21.0",
+  pinRev ? "29112bef099274229cadff79cdff7bf7b99c4b77",
+  pinHash ? "sha256-Ii9xP2fKUpvCcwWZuxJ0g3CZ+IL2UZH14pUNvBfdclc=",
 }:
 
 let


### PR DESCRIPTION
## Hermes Agent stable candidate

This PR is a quarantined upstream candidate. Merge it only after required checks pass.

| Contract | Current | Candidate |
| --- | --- | --- |
| Version | `0.20.4` | `0.21.0` |
| Revision | `e624e9fde561e1add9388384012b295fde669ade` | `29112bef099274229cadff79cdff7bf7b99c4b77` |
| Python | `>=3.11,<3.14` | `>=3.11,<3.14` |
| Config schema | `unknown` | `unknown` |
| Build validation | — | ❌ failed |

### Detected interface changes

- Direct dependencies: added: `firecrawl-anydoc`, `snowballstemmer`; changed: `uvicorn` (`uvicorn[standard]>=0.24.0,<1` → `uvicorn[standard]>=0.31.0,<1`)
- Optional dependency groups: none
- CLI entry points: none
- Package/module asset paths: none

Upstream: https://github.com/NousResearch/hermes-agent/releases/tag/v2026.8.31

<details><summary>Validation failure (last 80 lines)</summary>

```text
error: Cannot build '/nix/store/203gv5xybjlqsi6b79lhyi9vn8ns09bs-vm-test-run-hermes-skills-coexistence.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/s5qh2zs9hifjaq48vxzk51lylym2d51n-vm-test-run-hermes-skills-coexistence
❌ checks.x86_64-linux.cli-commands
error: Cannot build '/nix/store/3xlqqjx5ymdf4vrs54ry5kyjfc75l4cr-hermes-cli-commands.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/65d2xrqi6cx0056g86cf7i995wgih0yb-hermes-cli-commands
error: Cannot build '/nix/store/5ayw7z32n3g75x8h2lw8z9mnwfm0qli8-closure-info.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/88wp27n9kqr6282cp06sx0mpqv7z3lj9-closure-info
❌ checks.x86_64-linux.hermes-agent-import
error: Cannot build '/nix/store/a9xdmwyd9lml7nrp72lwbxawjqmjlnx7-hermes-agent-import.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/nlcbnvqr1j1nj58cq2kfq667vq10apn2-hermes-agent-import
error: Cannot build '/nix/store/fkcmzp78lkghy0bl57chws8vgz2r1pdq-hermes-agent-0.21.0.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/1mkxb54an1mxk6ayhs3wp9l2y13lglqa-hermes-agent-0.21.0
         /nix/store/lrzrira9h05179sxdk7kx4kasnv5xb50-hermes-agent-0.21.0-dist
       Last 25 log lines:
       > adding 'tui_gateway/server.py'
       > adding 'tui_gateway/slash_fuzzy.py'
       > adding 'tui_gateway/slash_worker.py'
       > adding 'tui_gateway/synthetic_turn.py'
       > adding 'tui_gateway/transport.py'
       > adding 'tui_gateway/turn_marker.py'
       > adding 'tui_gateway/ws.py'
       > adding 'hermes_agent-0.21.0.dist-info/METADATA'
       > adding 'hermes_agent-0.21.0.dist-info/WHEEL'
       > adding 'hermes_agent-0.21.0.dist-info/entry_points.txt'
       > adding 'hermes_agent-0.21.0.dist-info/top_level.txt'
       > adding 'hermes_agent-0.21.0.dist-info/RECORD'
       > removing build/bdist.linux-x86_64/wheel
       > Successfully built hermes_agent-0.21.0-py3-none-any.whl
       > Finished creating a wheel...
       > /build/source/dist /build/source
       > Unpacking to: unpacked/hermes_agent-0.21.0...OK
       > Repacking wheel as ./hermes_agent-0.21.0-py3-none-any.whl...OK
       > /build/source
       > Finished executing pypaBuildPhase
       > Running phase: pythonRuntimeDepsCheckHook
       > Executing pythonRuntimeDepsCheck
       > Checking runtime dependencies for hermes_agent-0.21.0-py3-none-any.whl
       >   - firecrawl-anydoc not installed
       >   - snowballstemmer not installed
       For full logs, run:
         nix log /nix/store/fkcmzp78lkghy0bl57chws8vgz2r1pdq-hermes-agent-0.21.0.drv
❌ checks.x86_64-linux.doctor
error: Cannot build '/nix/store/hd07r63wf5gh3l3j00qh8x8z1mdhil08-hermes-doctor.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/nv5pspjrcgs6av2zi909a5kdbq3ryxn7-hermes-doctor
error: Cannot build '/nix/store/jjg3ax6nzdpwn3sn8z12jxax710xk2g1-nixos-system-machine-test.drv'.
       Reason: 2 dependencies failed.
       Output paths:
         /nix/store/qmj5iaf2b74jhxisy0d4qxmp5iklnn38-nixos-system-machine-test
error: Cannot build '/nix/store/mchyv7kgpjwyvzhxialsd4xpm38x7mbd-nixos-test-driver-hermes-skills-coexistence.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/y65dpmqhr3l7jhi99iq1l1zypvllrf70-nixos-test-driver-hermes-skills-coexistence
error: Cannot build '/nix/store/n0yfzx51cjc28kxamq81sr0pbzs38f39-unit-hermes-agent.service.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/lmaihywb69wg04i0bxfp8229n4kk1r7k-unit-hermes-agent.service
✅ checks.x86_64-linux.skills-source-layout
❌ checks.x86_64-linux.package-contents
error: Cannot build '/nix/store/ww3qd6xpi35ls0ij4m664yh4wskkg7di-hermes-package-contents.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/56bsxraq51iffjqs03z9vglk2hr3llw5-hermes-package-contents
error: Cannot build '/nix/store/z11wl92jgcr2ldd90mc1cxrl3l617n01-run-nixos-vm.drv'.
       Reason: 2 dependencies failed.
       Output paths:
         /nix/store/q9qbj6x7kpmczbnqpp0a227s0pv69k65-run-nixos-vm
warning: The check omitted these incompatible systems: aarch64-darwin, aarch64-linux, x86_64-darwin
Use '--all-systems' to check all.
```
</details>
