### PR TITLE
chore: update Hermes Agent stable candidate

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -10,9 +10,9 @@
   ripgrep,
   ffmpeg,
   git,
-  pinVersion ? "0.21.0",
-  pinRev ? "29112bef099274229cadff79cdff7bf7b99c4b77",
-  pinHash ? "sha256-Ii9xP2fKUpvCcwWZuxJ0g3CZ+IL2UZH14pUNvBfdclc=",
+  pinVersion ? "0.21.1",
+  pinRev ? "2237be355906fbe6065ce1815711eee52b2d646e",
+  pinHash ? "sha256-2NuDx7rjsoBDO4I/iMoZsJ+5IaAbiNrDc+sFuzOe08w=",
 }:
 
 let


### PR DESCRIPTION
## Hermes Agent stable candidate

This PR is a quarantined upstream candidate. Merge it only after required checks pass.

| Contract | Current | Candidate |
| --- | --- | --- |
| Version | `0.21.0` | `0.21.1` |
| Revision | `29112bef099274229cadff79cdff7bf7b99c4b77` | `2237be355906fbe6065ce1815711eee52b2d646e` |
| Python | `>=3.11,<3.14` | `>=3.11,<3.14` |
| Config schema | `unknown` | `unknown` |
| Build validation | — | ✅ passed |

### Detected interface changes

- Direct dependencies: changed: `nemo-relay` (`nemo-relay>=0.7.1,<0.8; (sys_platform == 'darwin' and platform_machine == 'arm64') or (sys_platform == 'linux' and platform_machine == 'x86_64' and 'android' not in platform_release) or (sys_platform == 'linux' and platform_machine == 'aarch64' and 'android' not in platform_release) or (sys_platform == 'win32' and platform_machine == 'AMD64') or (sys_platform == 'win32' and platform_machine == 'ARM64')` → `nemo-relay>=0.8.3,<0.9; (sys_platform == 'darwin' and platform_machine == 'arm64') or (sys_platform == 'linux' and platform_machine == 'x86_64' and 'android' not in platform_release) or (sys_platform == 'linux' and platform_machine == 'aarch64' and 'android' not in platform_release) or (sys_platform == 'win32' and platform_machine == 'AMD64') or (sys_platform == 'win32' and platform_machine == 'ARM64')`)
- Optional dependency groups: none
- CLI entry points: none
- Package/module asset paths: none

Upstream: https://github.com/NousResearch/hermes-agent/releases/tag/v2026.9.7
